### PR TITLE
Scheduled snapshots for disks

### DIFF
--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -29,7 +29,14 @@ resource "google_compute_instance" "teamcity_server" {
   }
 
   boot_disk {
-    source = google_compute_disk.teamcity_server_boot_disk.self_link
+    initialize_params {
+      size = var.boot_disk_size_gb
+      type = var.boot_disk_type
+      image = coalesce(
+        var.boot_disk_image,
+        data.google_compute_image.teamcity_server.self_link,
+      )
+    }
   }
 
   network_interface {
@@ -48,18 +55,6 @@ resource "google_compute_instance" "teamcity_server" {
     device_name = local.data_device_name
     mode        = "READ_WRITE"
   }
-}
-
-resource "google_compute_disk" "teamcity_server_boot_disk" {
-  name = google_compute_disk.teamcity_server_data.name
-  zone = var.zone
-
-  size  = var.boot_disk_size_gb
-  type  = var.boot_disk_type
-  image = coalesce(
-    var.boot_disk_image,
-    data.google_compute_image.teamcity_server.self_link,
-  )
 }
 
 resource "google_compute_disk" "teamcity_server_data" {

--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -29,14 +29,7 @@ resource "google_compute_instance" "teamcity_server" {
   }
 
   boot_disk {
-    initialize_params {
-      size = var.boot_disk_size_gb
-      type = var.boot_disk_type
-      image = coalesce(
-        var.boot_disk_image,
-        data.google_compute_image.teamcity_server.self_link,
-      )
-    }
+    source = google_compute_disk.teamcity_server_boot_disk.self_link
   }
 
   network_interface {
@@ -55,6 +48,18 @@ resource "google_compute_instance" "teamcity_server" {
     device_name = local.data_device_name
     mode        = "READ_WRITE"
   }
+}
+
+resource "google_compute_disk" "teamcity_server_boot_disk" {
+  name = google_compute_disk.teamcity_server_data.name
+  zone = var.zone
+
+  size  = var.boot_disk_size_gb
+  type  = var.boot_disk_type
+  image = coalesce(
+    var.boot_disk_image,
+    data.google_compute_image.teamcity_server.self_link,
+  )
 }
 
 resource "google_compute_disk" "teamcity_server_data" {

--- a/server/terraform/snapshot.tf
+++ b/server/terraform/snapshot.tf
@@ -1,0 +1,49 @@
+resource "google_compute_resource_policy" "teamcity_server_data" {
+  provider = "google-beta"
+
+  name    = "scheduled-snapshot-for-${google_compute_disk.teamcity_server_data.name}"
+  project = var.project_id
+
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time = "20:00"
+      }
+    }
+    retention_policy {
+      max_retention_days = 5
+      on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
+    }
+    snapshot_properties {
+      labels = var.labels
+      storage_locations = ["asia-southeast1"]
+      guest_flush = false
+    }
+  }
+}
+
+resource "google_compute_resource_policy" "teamcity_server_boot_disk" {
+  provider = "google-beta"
+
+  name    = "scheduled-snapshot-for-${google_compute_disk.teamcity_server_boot_disk.name}"
+  project = var.project_id
+
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time = "20:00"
+      }
+    }
+    retention_policy {
+      max_retention_days = 5
+      on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
+    }
+    snapshot_properties {
+      labels = var.labels
+      storage_locations = ["asia-southeast1"]
+      guest_flush = false
+    }
+  }
+}

--- a/server/terraform/snapshot.tf
+++ b/server/terraform/snapshot.tf
@@ -3,21 +3,22 @@ resource "google_compute_resource_policy" "teamcity_server_data" {
 
   name    = "scheduled-snapshot-for-${google_compute_disk.teamcity_server_data.name}"
   project = var.project_id
+  region  = var.region
 
   snapshot_schedule_policy {
     schedule {
       daily_schedule {
-        days_in_cycle = 1
-        start_time = "20:00"
+        days_in_cycle = var.snapshot_days_in_cycle
+        start_time = var.snapshot_start_time
       }
     }
     retention_policy {
-      max_retention_days = 5
+      max_retention_days = var.max_retention_days
       on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
     }
     snapshot_properties {
       labels = var.labels
-      storage_locations = ["asia-southeast1"]
+      storage_locations = [var.region]
       guest_flush = false
     }
   }
@@ -28,7 +29,7 @@ resource "google_compute_resource_policy" "teamcity_server_data" {
     environment = {
       DISK_NAME = google_compute_disk.teamcity_server_data.self_link
       SCHEDULE_NAME = google_compute_resource_policy.teamcity_server_data.self_link
-      ZONE = var.zone
+      ZONE = google_compute_disk.teamcity_server_data.zone
     }
   }
 }

--- a/server/terraform/snapshot.tf
+++ b/server/terraform/snapshot.tf
@@ -22,28 +22,3 @@ resource "google_compute_resource_policy" "teamcity_server_data" {
     }
   }
 }
-
-resource "google_compute_resource_policy" "teamcity_server_boot_disk" {
-  provider = "google-beta"
-
-  name    = "scheduled-snapshot-for-${google_compute_disk.teamcity_server_boot_disk.name}"
-  project = var.project_id
-
-  snapshot_schedule_policy {
-    schedule {
-      daily_schedule {
-        days_in_cycle = 1
-        start_time = "20:00"
-      }
-    }
-    retention_policy {
-      max_retention_days = 5
-      on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
-    }
-    snapshot_properties {
-      labels = var.labels
-      storage_locations = ["asia-southeast1"]
-      guest_flush = false
-    }
-  }
-}

--- a/server/terraform/snapshot.tf
+++ b/server/terraform/snapshot.tf
@@ -21,4 +21,14 @@ resource "google_compute_resource_policy" "teamcity_server_data" {
       guest_flush = false
     }
   }
+
+  provisioner "local-exec" {
+    command = "gcloud beta compute disks add-resource-policies $DISK_NAME --resource-policies $SCHEDULE_NAME --zone $ZONE"
+
+    environment = {
+      DISK_NAME = google_compute_disk.teamcity_server_data.self_link
+      SCHEDULE_NAME = google_compute_resource_policy.teamcity_server_data.self_link
+      ZONE = var.zone
+    }
+  }
 }

--- a/server/terraform/variables.tf
+++ b/server/terraform/variables.tf
@@ -8,6 +8,10 @@ variable "description" {
   default     = "TeamCity Server"
 }
 
+variable "region" {
+  description = "Default region for GCP"
+}
+
 variable "zone" {
   description = "Zone to launch instance in"
 }
@@ -108,4 +112,19 @@ variable "data_disk_type" {
 variable "teamcity_memory_options" {
   description = "Memory options for TeamCity. See https://confluence.jetbrains.com/display/TCD18/Installing+and+Configuring+the+TeamCity+Server#InstallingandConfiguringtheTeamCityServer-SettingUpMemorysettingsforTeamCityServer"
   default     = "-Xmx1024m"
+}
+
+variable "snapshot_days_in_cycle" {
+  description = "Days between snapshots"
+  default     = 1
+}
+
+variable "snapshot_start_time" {
+  description = "This must be in UTC format that resolves to one of 00:00, 04:00, 08:00, 12:00, 16:00, or 20:00. For example, both 13:00-5 and 08:00 are valid."
+  default     = "20:00"
+}
+
+variable "max_retention_days" {
+  description = "Maximum age of the snapshot that is allowed to be kept."
+  default     = 5
 }


### PR DESCRIPTION
Changes:
- [x] Add snapshot schedules
- [x] Attach schedule to disks using local-exec.

Have to use local-exec as this feature has not been released yet: https://github.com/terraform-providers/terraform-provider-google-beta/pull/960 ; will add a TODO for this.