### PR TITLE
Recreate resource policy attachment

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -37,6 +37,22 @@ connecting to the local Postgres server:
 The local Postgres server is not accessible from outside the instance. If you prefer, you can use
 your own Postgres database elsewhere.
 
+## Terraform
+
+Included Terraform Module will help you provision TeamCity easily.
+
+### Reconfiguring scheduled snapshots
+
+GCP will create snapshots TeamCity instance's disk on a regular basis. If you change any of the associated values (for example `max_retention_days`) after you have already terraformed the first time, run this command first:
+
+```bash
+terraform apply -target=module.teamcity_server.null_resource.unattach_policy
+```
+
+This is necessary to detach the scheduled snapshot policy from the disk first, so terraform can successfully attach the modified policy.
+
+Then `terraform apply` as per normal.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -64,6 +80,10 @@ your own Postgres database elsewhere.
 | teamcity\_port | Port to expose TeamCity | string | `"80"` | no |
 | teamcity\_tag | TeamCity image tag to run | string | `"2018.2.2"` | no |
 | zone | Zone to launch instance in | string | n/a | yes |
+| region | Default region for GCP | string | n/a | yes |
+| snapshot\_days\_in\_cycle | Days between snapshots | number | 1 | no |
+| snapshot\_start\_time | Time of snapshot | string | `"20:00"` | no |
+| max\_retention\_days | Maximum age of the snapshot that is allowed to be kept | number | 5 | no |
 
 ## Outputs
 

--- a/server/terraform/snapshot.tf
+++ b/server/terraform/snapshot.tf
@@ -13,13 +13,13 @@ resource "null_resource" "unattach_policy" {
     start_time         = var.snapshot_start_time
   }
 
-   provisioner "local-exec" {
+  provisioner "local-exec" {
     command = "gcloud beta compute disks remove-resource-policies $DISK_NAME --resource-policies $SCHEDULE_NAME --zone $ZONE || true"
 
-     environment = {
-      DISK_NAME = google_compute_disk.teamcity_server_data.self_link
+    environment = {
+      DISK_NAME     = google_compute_disk.teamcity_server_data.self_link
       SCHEDULE_NAME = local.policy_name
-      ZONE = google_compute_disk.teamcity_server_data.zone
+      ZONE          = google_compute_disk.teamcity_server_data.zone
     }
   }
 }
@@ -35,17 +35,17 @@ resource "google_compute_resource_policy" "teamcity_server_data" {
     schedule {
       daily_schedule {
         days_in_cycle = var.snapshot_days_in_cycle
-        start_time = var.snapshot_start_time
+        start_time    = var.snapshot_start_time
       }
     }
     retention_policy {
-      max_retention_days = var.max_retention_days
+      max_retention_days    = var.max_retention_days
       on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
     }
     snapshot_properties {
-      labels = merge(var.labels, { checksum = null_resource.unattach_policy.id })
+      labels            = merge(var.labels, { checksum = null_resource.unattach_policy.id })
       storage_locations = [var.region]
-      guest_flush = false
+      guest_flush       = false
     }
   }
 
@@ -53,9 +53,9 @@ resource "google_compute_resource_policy" "teamcity_server_data" {
     command = "gcloud beta compute disks add-resource-policies $DISK_NAME --resource-policies $SCHEDULE_NAME --zone $ZONE"
 
     environment = {
-      DISK_NAME = google_compute_disk.teamcity_server_data.self_link
+      DISK_NAME     = google_compute_disk.teamcity_server_data.self_link
       SCHEDULE_NAME = local.policy_name
-      ZONE = google_compute_disk.teamcity_server_data.zone
+      ZONE          = google_compute_disk.teamcity_server_data.zone
     }
   }
 }

--- a/server/terraform/snapshot.tf
+++ b/server/terraform/snapshot.tf
@@ -1,7 +1,33 @@
+locals {
+  policy_name = "scheduled-snapshot-for-${google_compute_disk.teamcity_server_data.name}"
+}
+
+resource "null_resource" "unattach_policy" {
+  # Changes to any instance of the cluster requires re-provisioning
+  triggers = {
+    name               = local.policy_name
+    project            = var.project_id
+    region             = var.region
+    max_retention_days = var.max_retention_days
+    days_in_cycle      = var.snapshot_days_in_cycle
+    start_time         = var.snapshot_start_time
+  }
+
+   provisioner "local-exec" {
+    command = "gcloud beta compute disks remove-resource-policies $DISK_NAME --resource-policies $SCHEDULE_NAME --zone $ZONE || true"
+
+     environment = {
+      DISK_NAME = google_compute_disk.teamcity_server_data.self_link
+      SCHEDULE_NAME = local.policy_name
+      ZONE = google_compute_disk.teamcity_server_data.zone
+    }
+  }
+}
+
 resource "google_compute_resource_policy" "teamcity_server_data" {
   provider = "google-beta"
 
-  name    = "scheduled-snapshot-for-${google_compute_disk.teamcity_server_data.name}"
+  name    = local.policy_name
   project = var.project_id
   region  = var.region
 
@@ -17,7 +43,7 @@ resource "google_compute_resource_policy" "teamcity_server_data" {
       on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
     }
     snapshot_properties {
-      labels = var.labels
+      labels = merge(var.labels, { checksum = null_resource.unattach_policy.id })
       storage_locations = [var.region]
       guest_flush = false
     }
@@ -28,7 +54,7 @@ resource "google_compute_resource_policy" "teamcity_server_data" {
 
     environment = {
       DISK_NAME = google_compute_disk.teamcity_server_data.self_link
-      SCHEDULE_NAME = google_compute_resource_policy.teamcity_server_data.self_link
+      SCHEDULE_NAME = local.policy_name
       ZONE = google_compute_disk.teamcity_server_data.zone
     }
   }


### PR DESCRIPTION
Existing resource policy has to be detached first before the modified resource policy can be applied. Using null_resource to do so.

Also added README on instructions.