### PR TITLE
Attach snapshot policy to backup TC server data disk periodically

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -41,18 +41,6 @@ your own Postgres database elsewhere.
 
 Included Terraform Module will help you provision TeamCity easily.
 
-### Reconfiguring scheduled snapshots
-
-GCP will create snapshots TeamCity instance's disk on a regular basis. If you change any of the associated values (for example `max_retention_days`) after you have already terraformed the first time, run this command first:
-
-```bash
-terraform apply -target=module.teamcity_server.null_resource.unattach_policy
-```
-
-This is necessary to detach the scheduled snapshot policy from the disk first, so terraform can successfully attach the modified policy.
-
-Then `terraform apply` as per normal.
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -69,7 +69,7 @@ resource "google_compute_disk" "teamcity_server_data" {
   zone    = var.zone
   project = var.project_id
 
-  resource_policies = [google_compute_resource_policy.teamcity_server_data.self_link]
+  # resource_policies = [google_compute_resource_policy.teamcity_server_data.self_link]
 
   lifecycle {
     prevent_destroy = true

--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -58,6 +58,8 @@ resource "google_compute_instance" "teamcity_server" {
 }
 
 resource "google_compute_disk" "teamcity_server_data" {
+  provider = "google-beta"
+
   name        = var.data_disk_name
   description = "Disk holding the data for the TeamCity server instance ${var.name}"
 

--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -58,8 +58,6 @@ resource "google_compute_instance" "teamcity_server" {
 }
 
 resource "google_compute_disk" "teamcity_server_data" {
-  provider = "google-beta"
-
   name        = var.data_disk_name
   description = "Disk holding the data for the TeamCity server instance ${var.name}"
 
@@ -68,8 +66,6 @@ resource "google_compute_disk" "teamcity_server_data" {
   type    = var.data_disk_type
   zone    = var.zone
   project = var.project_id
-
-  # resource_policies = [google_compute_resource_policy.teamcity_server_data.self_link]
 
   lifecycle {
     prevent_destroy = true

--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -67,6 +67,8 @@ resource "google_compute_disk" "teamcity_server_data" {
   zone    = var.zone
   project = var.project_id
 
+  resource_policies = [google_compute_resource_policy.teamcity_server_data.self_link]
+
   lifecycle {
     prevent_destroy = true
   }

--- a/server/terraform/snapshot.tf
+++ b/server/terraform/snapshot.tf
@@ -1,5 +1,5 @@
 locals {
-  policy_name = "scheduled-snapshot-for-${google_compute_disk.teamcity_server_data.name}"
+  policy_name = "scheduled-snapshot-for-${var.data_disk_name}"
 }
 
 resource "google_compute_resource_policy" "teamcity_server_data" {
@@ -21,7 +21,7 @@ resource "google_compute_resource_policy" "teamcity_server_data" {
       on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
     }
     snapshot_properties {
-      labels            = merge(var.labels, { checksum = null_resource.unattach_policy.id })
+      labels            = var.labels
       storage_locations = [var.region]
       guest_flush       = false
     }

--- a/server/terraform/snapshot.tf
+++ b/server/terraform/snapshot.tf
@@ -3,8 +3,6 @@ locals {
 }
 
 resource "google_compute_resource_policy" "teamcity_server_data" {
-  provider = "google-beta"
-
   name    = local.policy_name
   project = var.project_id
   region  = var.region
@@ -26,4 +24,11 @@ resource "google_compute_resource_policy" "teamcity_server_data" {
       guest_flush       = false
     }
   }
+}
+
+resource "google_compute_disk_resource_policy_attachment" "teamcity_server_data" {
+  zone    = var.zone
+  project = var.project_id
+  disk    = google_compute_disk.teamcity_server_data.name
+  name    = google_compute_resource_policy.teamcity_server_data.self_link
 }

--- a/server/terraform/snapshot.tf
+++ b/server/terraform/snapshot.tf
@@ -2,28 +2,6 @@ locals {
   policy_name = "scheduled-snapshot-for-${google_compute_disk.teamcity_server_data.name}"
 }
 
-resource "null_resource" "unattach_policy" {
-  # Changes to any instance of the cluster requires re-provisioning
-  triggers = {
-    name               = local.policy_name
-    project            = var.project_id
-    region             = var.region
-    max_retention_days = var.max_retention_days
-    days_in_cycle      = var.snapshot_days_in_cycle
-    start_time         = var.snapshot_start_time
-  }
-
-  provisioner "local-exec" {
-    command = "gcloud beta compute disks remove-resource-policies $DISK_NAME --resource-policies $SCHEDULE_NAME --zone $ZONE || true"
-
-    environment = {
-      DISK_NAME     = google_compute_disk.teamcity_server_data.self_link
-      SCHEDULE_NAME = local.policy_name
-      ZONE          = google_compute_disk.teamcity_server_data.zone
-    }
-  }
-}
-
 resource "google_compute_resource_policy" "teamcity_server_data" {
   provider = "google-beta"
 
@@ -46,16 +24,6 @@ resource "google_compute_resource_policy" "teamcity_server_data" {
       labels            = merge(var.labels, { checksum = null_resource.unattach_policy.id })
       storage_locations = [var.region]
       guest_flush       = false
-    }
-  }
-
-  provisioner "local-exec" {
-    command = "gcloud beta compute disks add-resource-policies $DISK_NAME --resource-policies $SCHEDULE_NAME --zone $ZONE"
-
-    environment = {
-      DISK_NAME     = google_compute_disk.teamcity_server_data.self_link
-      SCHEDULE_NAME = local.policy_name
-      ZONE          = google_compute_disk.teamcity_server_data.zone
     }
   }
 }

--- a/server/terraform/snapshot.tf
+++ b/server/terraform/snapshot.tf
@@ -30,5 +30,5 @@ resource "google_compute_disk_resource_policy_attachment" "teamcity_server_data"
   zone    = var.zone
   project = var.project_id
   disk    = google_compute_disk.teamcity_server_data.name
-  name    = google_compute_resource_policy.teamcity_server_data.self_link
+  name    = google_compute_resource_policy.teamcity_server_data.name
 }


### PR DESCRIPTION
Fixes: https://github.com/basisai/teamcity-gcp/issues/9

Using https://www.terraform.io/docs/providers/google/r/compute_disk_resource_policy_attachment.html