### PR TITLE
Create remote temp dir with sufficient permissions

### DIFF
--- a/agent/packer/packer.json
+++ b/agent/packer/packer.json
@@ -60,6 +60,10 @@
         },
         {
             "type": "ansible",
+            "ansible_env_vars": [
+                "ANSIBLE_PIPELINING=yes",
+                "ANSIBLE_REMOTE_TMP=/tmp/.ansible"
+            ],
             "playbook_file": "{{ template_dir }}/site.yml",
             "extra_arguments": [
                 "-e",

--- a/agent/packer/site.yml
+++ b/agent/packer/site.yml
@@ -17,6 +17,12 @@
     telegraf_global_tags: |
       usage = "teamcity-agent"
   tasks:
+  - name: Create remote temp directory
+    file:
+      path: "{{ lookup('env', 'ANSIBLE_REMOTE_TMP') }}"
+      mode: 0777
+      state: directory
+    become: yes
   - name: Upgrade all packages to the latest version
     apt:
       upgrade: yes


### PR DESCRIPTION
Due to the use of OSLogin user, the remote temp directory needs to be assigned the appropriate file permissions.