### PR TITLE
BDRK-3381: Add LetsEncrypt mount bind to fstab

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Order is important; the last matching pattern takes the most
+# precedence.
+# https://help.github.com/en/articles/about-code-owners
+* @basisai/infrastructure

--- a/server/terraform/templates/startup.sh
+++ b/server/terraform/templates/startup.sh
@@ -77,9 +77,16 @@ function mount_data() {
     mkdir -p /etc/letsencrypt/{live,renewal,archive}
     mkdir -p $${mount_path}/letsencrypt/{live,renewal,archive}
     for dir in live renewal archive
-        do
-            mount -o bind $${mount_path}/letsencrypt/$dir /etc/letsencrypt/$dir
-        done
+    do
+        if [ -z "$(grep $${mount_path}/letsencrypt/$dir /etc/fstab)" ]
+        then
+            echo "$${mount_path}/letsencrypt/$dir /etc/letsencrypt/$dir none rw,bind 0 0" >> /etc/fstab
+        fi
+        mount -o bind $${mount_path}/letsencrypt/$dir /etc/letsencrypt/$dir
+    done
+
+    # Safety Check
+    mount -a
 }
 
 function configure_teamcity() {


### PR DESCRIPTION
Add LetsEncrypt mount bind to /etc/fstab, so docker-compose will not crash when we reboot server.